### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/README.md
+++ b/kubernetes-controllers/README.md
@@ -1,0 +1,90 @@
+# Выполнено ДЗ № 2
+
+ - [x] Основное ДЗ
+ - [x] Задание со *
+ - [x] Задание с **
+
+## В процессе сделано:
+- Развернут локальный кластер k8s на основе [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) 
+- ReplicaSet ***frontend-replicaset.yaml*** задеплоен и протестирован.
+- Deployment ***frontend-deployment.yaml*** задеплоен и протестирован.
+- Собран образ ***paymentservice*** и отправлен в репозиторий [https://hub.docker.com/r/voitenkov/hipster-paymentservice](https://hub.docker.com/r/voitenkov/hipster-paymentservice)
+- ReplicaSet ***paymentservice-replicaset.yaml*** задеплоен и протестирован.
+- Deployment ***paymentservice-deployment.yaml*** задеплоен и протестирован.
+- Blue-green сценарий развертывания ***paymentservice-deployment-bg.yaml*** задеплоен и протестирован.
+- Reverse Rolling Update сценарий развертывания ***paymentservice-deployment-reverse.yaml*** задеплоен и протестирован.
+- ReadynessProbe добавлен в ***frontend-deployment.yaml*** и протестирован.
+- Сценарий неудачного обновления и его отката (Rollback) протестирован.
+- DaemonSet для node-exporter ***node-exporter-daemonset.yaml*** задеплоен и протестирован на все ноды, включая Master.
+---
+### Решение Д/З №2
+
+- Руководствуясь материалами лекции опишите произошедшую ситуацию, почему обновление ReplicaSet не повлекло обновление запущенных pod?
+
+Ответ: 
+ReplicaSet не умеет рестартовать запущенные поды при обновлении шаблона, для этого придуман Deployment.
+
+- ⭐ Deployment | С использованием параметров **maxSurge** и **maxUnavailable** самостоятельно реализуйте два следующих сценария развертывания:
+1. Аналог blue-green:
+ - Развертывание трех новых pod
+ - Удаление трех старых pod
+
+Результат - ***paymentservice-deployment-bg.yaml***
+```shell
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100% 
+```
+
+2. Reverse Rolling Update:
+  - Удаление одного старого pod
+  - Создание одного нового pod 
+  - ....
+  - ....
+
+Результат - ***paymentservice-deployment-reverse.yaml***
+```shell
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0 
+```
+
+- ⭐ Написать манифест DaemonSet для node-exporter
+
+Опробуем DaemonSet на примере [Node Exporter](https://github.com/prometheus/node_exporter)
+1. Найдите в интернете или напишите самостоятельно манифест node-exporter-daemonset.yaml для развертывания DaemonSet с Node Exporter.
+2. После применения данного DaemonSet и выполнения команды:
+ ```shell
+ kubectl port-forward <имя любого pod в DaemonSet> 9100:9100
+ ```
+метрики должны быть доступны на localhost: curl localhost:9100/metrics
+
+- ⭐⭐ DaemonSet на Master и Worker nodes
+Как правило, мониторинг требуется не только для worker, но и для master нод. При этом, по умолчанию, pod управляемые DaemonSet на master нодах не разворачиваются 
+Найдите способ модернизировать свой DaemonSet таким образом, чтобы Node Exporter был развернут как на master, так и на worker нодах (конфигурацию самих нод изменять нельзя) 
+Отразите изменения в манифесте.
+
+Нужно добавить: 
+```shell
+    spec:
+      tolerations:
+      - operator: "Exists"
+```
+Результат - ***node-exporter-daemonset.yaml***
+
+### Как проверить работоспособность:
+
+ - Выполнить команды:
+  ```shell
+  kubectl apply -f node-exporter-daemonset.yaml 
+  kubectl port-forward <имя любого pod в DaemonSet> 9100:9100
+  curl localhost:9100/metrics
+  ```
+## PR checklist:
+ - [x] Выставлен label с темой домашнего задания

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: voitenkov/hipster-frontend:v0.0.2
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENABLE_PROFILER
+          value: "0"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: voitenkov/hipster-frontend:v0.0.2
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENABLE_PROFILER
+          value: "0"

--- a/kubernetes-controllers/kind-config.yaml
+++ b/kubernetes-controllers/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1  
+kind: DaemonSet
+metadata:  
+  name: node-exporter
+  labels:  
+    app: node-exporter    
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter  
+  template:  
+    metadata:  
+      labels:  
+        app: node-exporter
+    spec:
+      tolerations:
+      - operator: "Exists"
+      containers:  
+      - image: prom/node-exporter  
+        name: node-exporter  
+        ports:  
+        - containerPort: 9100  
+          protocol: TCP  
+
+  

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100% 
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: voitenkov/hipster-paymentservice:v0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0 
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: voitenkov/hipster-paymentservice:v0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: voitenkov/hipster-paymentservice:v0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: voitenkov/hipster-paymentservice:v0.0.1
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [x] Основное ДЗ
 - [x] Задание со *
 - [x] Задание с **

## В процессе сделано:
- Развернут локальный кластер k8s на основе [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) 
- ReplicaSet ***frontend-replicaset.yaml*** задеплоен и протестирован.
- Deployment ***frontend-deployment.yaml*** задеплоен и протестирован.
- Собран образ ***paymentservice*** и отправлен в репозиторий [https://hub.docker.com/r/voitenkov/hipster-paymentservice](https://hub.docker.com/r/voitenkov/hipster-paymentservice)
- ReplicaSet ***paymentservice-replicaset.yaml*** задеплоен и протестирован.
- Deployment ***paymentservice-deployment.yaml*** задеплоен и протестирован.
- Blue-green сценарий развертывания ***paymentservice-deployment-bg.yaml*** задеплоен и протестирован.
- Reverse Rolling Update сценарий развертывания ***paymentservice-deployment-reverse.yaml*** задеплоен и протестирован.
- ReadynessProbe добавлен в ***frontend-deployment.yaml*** и протестирован.
- Сценарий неудачного обновления и его отката (Rollback) протестирован.
- DaemonSet для node-exporter ***node-exporter-daemonset.yaml*** задеплоен и протестирован на все ноды, включая Master.
---
### Решение Д/З №2

- Руководствуясь материалами лекции опишите произошедшую ситуацию, почему обновление ReplicaSet не повлекло обновление запущенных pod?

Ответ: 
ReplicaSet не умеет рестартовать запущенные поды при обновлении шаблона, для этого придуман Deployment.

- ⭐ Deployment | С использованием параметров **maxSurge** и **maxUnavailable** самостоятельно реализуйте два следующих сценария развертывания:
1. Аналог blue-green:
 - Развертывание трех новых pod
 - Удаление трех старых pod

Результат - ***paymentservice-deployment-bg.yaml***
```shell
  replicas: 3
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 100% 
```

2. Reverse Rolling Update:
  - Удаление одного старого pod
  - Создание одного нового pod 
  - ....
  - ....

Результат - ***paymentservice-deployment-reverse.yaml***
```shell
  replicas: 3
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
      maxSurge: 0 
```

- ⭐ Написать манифест DaemonSet для node-exporter

Опробуем DaemonSet на примере [Node Exporter](https://github.com/prometheus/node_exporter)
1. Найдите в интернете или напишите самостоятельно манифест node-exporter-daemonset.yaml для развертывания DaemonSet с Node Exporter.
2. После применения данного DaemonSet и выполнения команды:
 ```shell
 kubectl port-forward <имя любого pod в DaemonSet> 9100:9100
 ```
метрики должны быть доступны на localhost: curl localhost:9100/metrics

- ⭐⭐ DaemonSet на Master и Worker nodes
Как правило, мониторинг требуется не только для worker, но и для master нод. При этом, по умолчанию, pod управляемые DaemonSet на master нодах не разворачиваются 
Найдите способ модернизировать свой DaemonSet таким образом, чтобы Node Exporter был развернут как на master, так и на worker нодах (конфигурацию самих нод изменять нельзя) 
Отразите изменения в манифесте.

Нужно добавить: 
```shell
    spec:
      tolerations:
      - operator: "Exists"
```
Результат - ***node-exporter-daemonset.yaml***

### Как проверить работоспособность:

 - Выполнить команды:
  ```shell
  kubectl apply -f node-exporter-daemonset.yaml 
  kubectl port-forward <имя любого pod в DaemonSet> 9100:9100
  curl localhost:9100/metrics
  ```
## PR checklist:
 - [x] Выставлен label с темой домашнего задания