### PR TITLE
Kubernetes volumes

### DIFF
--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,0 +1,40 @@
+### Выполненное Д/З №4
+
+- [x] Основное ДЗ
+- [x] Задание со *
+
+ДЗ выполняется на основе kind
+
+Запуск 
+```
+kind create cluster
+export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+```
+#### В этом ДЗ мы развернем StatefulSet c [minIO](https://min.io/) - локальным S3 хранилищем
+minio-statefulset.yaml
+В результате применения конфигурации должно произойти следующее:
+- Запуститься под с MinIO
+- Создаться PVC
+- Динамически создаться PV на этом PVC с помощью дефолотного StorageClass
+
+Для того, чтобы наш StatefulSet был доступен изнутри кластера, создадим Headless Service - minio-headlessservice.yaml 
+
+#### ⭐ В конфигурации нашего StatefulSet данные указаны в открытом виде, что не безопасно. Поместите данные в secrets и настройте конфигурацию на их использование.
+- файл secret.yaml
+- плюс исравленный файл minio-statefulset.yaml
+
+## Как запустить проект:
+ - Запустить команду **kubectl apply -f kubernetes-volumes**
+
+## Как проверить работоспособность:
+### Web-сервер nginx:
+ - Выполнить команды:
+```shell
+kubectl get statefulsets
+kubectl get pods
+kubectl get pvc
+kubectl get pv
+kubectl describe <resource> <resource_name>
+```
+## PR checklist:
+ - [x] Выставлен label с темой домашнего задания

--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -15,13 +15,13 @@ minio-statefulset.yaml
 В результате применения конфигурации должно произойти следующее:
 - Запуститься под с MinIO
 - Создаться PVC
-- Динамически создаться PV на этом PVC с помощью дефолотного StorageClass
+- Динамически создаться PV на этом PVC с помощью дефолтного StorageClass
 
 Для того, чтобы наш StatefulSet был доступен изнутри кластера, создадим Headless Service - minio-headlessservice.yaml 
 
 #### ⭐ В конфигурации нашего StatefulSet данные указаны в открытом виде, что не безопасно. Поместите данные в secrets и настройте конфигурацию на их использование.
 - файл secret.yaml
-- плюс исравленный файл minio-statefulset.yaml
+- плюс исправленный файл minio-statefulset.yaml
 
 ## Как запустить проект:
  - Запустить команду **kubectl apply -f kubernetes-volumes**

--- a/kubernetes-volumes/minio-headlessservice.yaml
+++ b/kubernetes-volumes/minio-headlessservice.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -17,11 +17,17 @@ spec:
       containers:
       - name: minio
         env:
-        - name: MINIO_ACCESS_KEY
-          value: "minio"
-        - name: MINIO_SECRET_KEY
-          value: "minio123"
-        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: root_user
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: root_pass
+        image: minio/minio
         args:
         - server
         - /data 
@@ -51,4 +57,4 @@ spec:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 10Gi
+          storage: 1Gi

--- a/kubernetes-volumes/secrets.yaml
+++ b/kubernetes-volumes/secrets.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  labels:
+    app: minio
+data:
+  root_user: bWluaW8=
+  root_pass: bWluaW8xMjM=
+type: Opaque


### PR DESCRIPTION
### Выполненное Д/З №4

- [x] Основное ДЗ
- [x] Задание со *

ДЗ выполняется на основе kind

Запуск 
```
kind create cluster
export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
```
#### В этом ДЗ мы развернем StatefulSet c [minIO](https://min.io/) - локальным S3 хранилищем
minio-statefulset.yaml
В результате применения конфигурации должно произойти следующее:
- Запуститься под с MinIO
- Создаться PVC
- Динамически создаться PV на этом PVC с помощью дефолтного StorageClass

Для того, чтобы наш StatefulSet был доступен изнутри кластера, создадим Headless Service - minio-headlessservice.yaml 

#### ⭐ В конфигурации нашего StatefulSet данные указаны в открытом виде, что не безопасно. Поместите данные в secrets и настройте конфигурацию на их использование.
- файл secret.yaml
- плюс исправленный файл minio-statefulset.yaml

## Как запустить проект:
 - Запустить команду **kubectl apply -f kubernetes-volumes**

## Как проверить работоспособность:
### Web-сервер nginx:
 - Выполнить команды:
```shell
kubectl get statefulsets
kubectl get pods
kubectl get pvc
kubectl get pv
kubectl describe <resource> <resource_name>
```
## PR checklist:
 - [x] Выставлен label с темой домашнего задания